### PR TITLE
Fixed typo in goals-signals-metrics.md

### DIFF
--- a/goals-signals-metrics.md
+++ b/goals-signals-metrics.md
@@ -154,7 +154,7 @@ Example metrics for our "reliability" goal from above might be something like:
   then count how often UI interactions happen _under_ those thresholds. (Display
   a percentage of how many UI interactions have an "acceptable" latency.)
 
-If you look at our signals above, you will see that some of these map back to
+If you look at our metrics above, you will see that some of these map back to
 our signals.
 
 Overall, there is a _lot_ to know about metrics, including what makes metrics


### PR DESCRIPTION
Fixed typo, replaced signals with metrics.